### PR TITLE
Run wheel generation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,7 +9,7 @@ defaults:
     shell: bash
 
 jobs:
-  deploy-pypi:
+  pre-deploy-checks:
     name: Deploy to PyPI
     runs-on: ubuntu-latest
     steps:
@@ -25,10 +25,25 @@ jobs:
       - name: Run tests
         run: |
           poetry run pytest -r a src tests --doctest-modules
-      - name: Publish to PyPI
-        env:
-          PYPI_TOKEN: "${{ secrets.PYPI_TOKEN }}"
 
-        run: |
-          poetry config pypi-token.pypi $PYPI_TOKEN
-          poetry publish --build --no-interaction
+  upload-all:
+    name: Upload if release
+    needs: [ build_wheels, build_sdist, pre-deploy-checks ]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          merge-multiple: true
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -48,8 +48,6 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64
-          # Use Ninja for generating the Windows project
-          CIBW_BEFORE_ALL: set CMAKE_ARGS="-GNinja"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -36,12 +36,15 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os:
+          - ubuntu-latest
+          # Disabling Windows build until https://gitlab.com/magicc/fgen/-/issues/79 is resolved
+          # - windows-latest
+          # macos-13 is an intel runner, macos-14 is apple silicon
+          - macos-13
+          - macos-14
+        # Using the same version of gcc for all builds
         toolchain: [{compiler: gcc, version: 12}]
-#        include:
-#          - os: windows-2022
-#            toolchain: { compiler: intel, version: '2024.1' }
 
     steps:
       - uses: actions/checkout@v4
@@ -66,6 +69,7 @@ jobs:
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_WINDOWS: auto ARM64
+          # Explicitly specifying the Ninja Generator is required for gfortran builds on Windows
           CMAKE_GENERATOR: Ninja
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         toolchain: [{compiler: gcc, version: 12}]
-        include:
-          - os: windows-2022
-            toolchain: { compiler: intel, version: '2024.1' }
+#        include:
+#          - os: windows-2022
+#            toolchain: { compiler: intel, version: '2024.1' }
 
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +48,8 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64
+          # Use Ninja for generating the Windows project
+          CIBW_BEFORE_ALL: export CMAKE_ARGS="-GNinja"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -12,6 +12,23 @@ on:
     workflow_dispatch:
 
 jobs:
+  build_sdist:
+    name: Build SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build SDist
+        run: pipx run build --sdist
+
+      - name: Check metadata
+        run: pipx run twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -48,6 +65,8 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS_WINDOWS: auto ARM64
+          CMAKE_GENERATOR: Ninja
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -38,6 +38,7 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_BEFORE_ALL_MACOS: alias gfortran=gfortran-12
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,12 +1,23 @@
 # Workflow to build and test wheels
+# See [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/) for additional configuration options
 name: Wheel builder
-on: [push, pull_request]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+    workflow_dispatch:
 
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,0 +1,34 @@
+# Workflow to build and test wheels
+name: Wheel builder
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.17.0
+        env:
+          # configure cibuildwheel to build native archs ('auto'), and some
+          # emulated ones
+          CIBW_ARCHS_LINUX: auto aarch64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -49,7 +49,7 @@ jobs:
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64
           # Use Ninja for generating the Windows project
-          CIBW_BEFORE_ALL: export CMAKE_ARGS="-GNinja"
+          CIBW_BEFORE_ALL: set CMAKE_ARGS="-GNinja"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -20,8 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-13, macos-14]
         toolchain: [{compiler: gcc, version: 12}]
+        include:
+          - os: windows-latest
+            toolchain: { compiler: intel, version: 2024.1 }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -23,8 +23,8 @@ jobs:
         os: [ubuntu-latest, macos-13, macos-14]
         toolchain: [{compiler: gcc, version: 12}]
         include:
-          - os: windows-latest
-            toolchain: { compiler: intel, version: 2024.1 }
+          - os: windows-2022
+            toolchain: { compiler: intel, version: '2024.1' }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -21,9 +21,16 @@ jobs:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        toolchain: [{compiler: gcc, version: 12}]
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: fortran-lang/setup-fortran@v1
+        id: setup-fortran
+        with:
+          compiler: ${{ matrix.toolchain.compiler }}
+          version: ${{ matrix.toolchain.version }}
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -38,7 +45,6 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64
-          CIBW_BEFORE_ALL_MACOS: alias gfortran=gfortran-12
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -3,7 +3,8 @@
 name: Wheel builder
 
 on:
-  pull_request:
+  # Not running wheel generation on every PR
+  #  pull_request:
   push:
     branches:
       - main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(
 
 # Find f2py header files
 execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" -c "import numpy.f2py; print(numpy.f2py.get_include())"
+  COMMAND "${PYTHON_EXECUTABLE}" -c "import numpy.f2py; print(numpy.f2py.get_include().replace('\\\\', '/'))"
   OUTPUT_VARIABLE F2PY_INCLUDE_DIR
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )

--- a/changelog/3.improvement.md
+++ b/changelog/3.improvement.md
@@ -1,0 +1,2 @@
+Build a set of pre-compiled wheels for a range of Python versions
+and operating systems.

--- a/poetry.lock
+++ b/poetry.lock
@@ -141,31 +141,6 @@ rich = "*"
 tomli = "*"
 
 [[package]]
-name = "cattrs"
-version = "23.2.3"
-description = "Composable complex class support for attrs and dataclasses."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "cattrs-23.2.3-py3-none-any.whl", hash = "sha256:0341994d94971052e9ee70662542699a3162ea1e0c62f7ce1b4a57f563685108"},
-    {file = "cattrs-23.2.3.tar.gz", hash = "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f"},
-]
-
-[package.dependencies]
-attrs = ">=23.1.0"
-exceptiongroup = {version = ">=1.1.1", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.1.0,<4.6.3 || >4.6.3", markers = "python_version < \"3.11\""}
-
-[package.extras]
-bson = ["pymongo (>=4.4.0)"]
-cbor2 = ["cbor2 (>=5.4.6)"]
-msgpack = ["msgpack (>=1.0.5)"]
-orjson = ["orjson (>=3.9.2)"]
-pyyaml = ["pyyaml (>=6.0)"]
-tomlkit = ["tomlkit (>=0.11.8)"]
-ujson = ["ujson (>=5.7.0)"]
-
-[[package]]
 name = "certifi"
 version = "2024.2.2"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -582,30 +557,6 @@ files = [
 
 [package.extras]
 devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benchmark", "pytest-cache", "validictory"]
-
-[[package]]
-name = "fgen"
-version = "0.4.1"
-description = "Automatically generate wrapper to integrate Fortran and Python"
-optional = false
-python-versions = "<4.0,>=3.9"
-files = [
-    {file = "fgen-0.4.1-py3-none-any.whl", hash = "sha256:07c4ffc642b991a76d60cc0e96f2486c0bfad26829f5b43be0c756bc2b253c15"},
-    {file = "fgen-0.4.1.tar.gz", hash = "sha256:0b31ab8558da514757c0107d63715d12788ab8b846fe57773a15348b27b5df5e"},
-]
-
-[package.dependencies]
-attrs = ">=23.0.0,<24.0.0"
-cattrs = ">=23.0.0,<24.0.0"
-click = ">=8.0.0,<9.0.0"
-loguru = ">=0.7.2,<0.8.0"
-numpy = ">1.23"
-pint = "*"
-pyyaml = ">=6.0,<7.0"
-typing-extensions = ">=4.9.0,<5.0.0"
-
-[package.extras]
-templates = ["black (>=23.3.0,<24.0.0)", "jinja2 (>=3.1.2,<4.0.0)"]
 
 [[package]]
 name = "filelock"
@@ -1049,24 +1000,6 @@ semantic-version = ">=2.7.0"
 toml = "*"
 
 [[package]]
-name = "loguru"
-version = "0.7.2"
-description = "Python logging made (stupidly) simple"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "loguru-0.7.2-py3-none-any.whl", hash = "sha256:003d71e3d3ed35f0f8984898359d65b79e5b21943f78af86aa5491210429b8eb"},
-    {file = "loguru-0.7.2.tar.gz", hash = "sha256:e671a53522515f34fd406340ee968cb9ecafbc4b36c679da03c18fd8d0bd51ac"},
-]
-
-[package.dependencies]
-colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
-win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
-
-[package.extras]
-dev = ["Sphinx (==7.2.5)", "colorama (==0.4.5)", "colorama (==0.4.6)", "exceptiongroup (==1.1.3)", "freezegun (==1.1.0)", "freezegun (==1.2.2)", "mypy (==v0.910)", "mypy (==v0.971)", "mypy (==v1.4.1)", "mypy (==v1.5.1)", "pre-commit (==3.4.0)", "pytest (==6.1.2)", "pytest (==7.4.0)", "pytest-cov (==2.12.1)", "pytest-cov (==4.1.0)", "pytest-mypy-plugins (==1.9.3)", "pytest-mypy-plugins (==3.0.0)", "sphinx-autobuild (==2021.3.14)", "sphinx-rtd-theme (==1.3.0)", "tox (==3.27.1)", "tox (==4.11.0)"]
-
-[[package]]
 name = "markdown-it-py"
 version = "2.2.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1395,51 +1328,6 @@ files = [
 setuptools = "*"
 
 [[package]]
-name = "numpy"
-version = "1.26.4"
-description = "Fundamental package for array computing in Python"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
-    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
-    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
-    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
-    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
-    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
-    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
-    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
-    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
-    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
-    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
-    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
-    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
-    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
-    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
-    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
-    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
-    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
-    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
-    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
-    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
-    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
-    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
-    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
-    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
-    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
-    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
-    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
-    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
-    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
-    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
-    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
-    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
-]
-
-[[package]]
 name = "packaging"
 version = "24.0"
 description = "Core utilities for Python packages"
@@ -1489,30 +1377,6 @@ files = [
 
 [package.dependencies]
 ptyprocess = ">=0.5"
-
-[[package]]
-name = "pint"
-version = "0.22"
-description = "Physical quantities module"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "Pint-0.22-py3-none-any.whl", hash = "sha256:6e2b3c5c2b4d9b516608bc860a417a39d66eb99c958f36540cf931d2c2e9f80f"},
-    {file = "Pint-0.22.tar.gz", hash = "sha256:2d139f6abbcf3016cad7d3cec05707fe908ac4f99cf59aedfd6ee667b7a64433"},
-]
-
-[package.dependencies]
-typing-extensions = "*"
-
-[package.extras]
-babel = ["babel (<=2.8)"]
-dask = ["dask"]
-mip = ["mip (>=1.13)"]
-numpy = ["numpy (>=1.19.5)"]
-pandas = ["pint-pandas (>=0.3)"]
-test = ["pytest", "pytest-cov", "pytest-mpl", "pytest-subtests"]
-uncertainties = ["uncertainties (>=3.1.6)"]
-xarray = ["xarray"]
 
 [[package]]
 name = "platformdirs"
@@ -2607,20 +2471,6 @@ files = [
 ]
 
 [[package]]
-name = "win32-setctime"
-version = "1.1.0"
-description = "A small Python utility to set file creation time on Windows"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
-    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
-]
-
-[package.extras]
-dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
-
-[[package]]
 name = "zipp"
 version = "3.18.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -2638,4 +2488,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a2940525b091fe6373a6285b400399fdf122f7116f408a2f3fd0ba47a2615e6b"
+content-hash = "210759ef096acba6de2aa199a18932d8f84d39c75724197704fdd38b3da77021"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pint >= 0.22",
     "numpy >= 0.22",
-    "fgen == 0.3.1",
+    "fgen == 0.4.1",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,7 +277,5 @@ manylinux-x86_64-image = "manylinux_2_28"
 test-command = "python -c 'from fgen_example.derived_type import DerivedType; print(DerivedType.from_new_connection())'"
 
 [tool.cibuildwheel.windows]
-# Use Ninja for generating the Windows project
-# This is needed because we are using gfortran
-before-all = "set CMAKE_GENERATOR=Ninja"
+before-all = ""
 before-build = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,13 @@ authors = [{name = "Jared Lewis, email = jared.lewis@climate-resource.com"}]
 # via https://scikit-build-core.readthedocs.io/en/latest/getting_started.html#python-package-configuration
 # (https://gitlab.com/magicc/copier-fgen-based-repository/-/issues/1)
 packages = [{include = "fgen_example", from = "src"}]
+requires-python = ">=3.10"
+dependencies = [
+    "pint >= 0.22",
+    "numpy >= 0.22",
+    "fgen == 0.3.1",
+]
+
 
 [tool.poetry]
 name = "fgen-example"
@@ -19,11 +26,10 @@ readme = "README.md"
 authors = ["Jared Lewis <jared.lewis@climate-resource.com>"]
 packages = [{include = "fgen_example", from = "src"}]
 
+# The real project dependencies are not managed here
+# TODO: remove once #1 is resolved and poetry@2 is released
 [tool.poetry.dependencies]
 python = "^3.9"
-pint = "^0.22"
-numpy = "^1.25.2"
-fgen = "0.4.1"
 
 [tool.poetry.group.tests.dependencies]
 pytest = "^7.3.1"
@@ -246,6 +252,30 @@ unauthorized_licenses = [
     "gpl v1",
     "gplv1",
 ]
-[tool.liccheck.authorized_packages]
-# TODO: remove when updating fgen
-cmakelang = "0.6.13"
+
+[tool.cibuildwheel]
+before-all = "uname -a"
+before-build = "rm -rf {project}/build"
+
+# Specify the builds that will be performed
+# See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip for the list of build targets.
+# Skipping
+#  - CPython 3.6 - 3.9: EOLed
+#  - All pypy builds: Not used
+#  - i686, s390x and ppc64le archs: Not used/supported
+#  - musllinux (alpine): not supported
+build = "cp310* cp311* cp312*"
+skip = "pp*  *_i686 *_ppc64le *_s390x *-musllinux_*"
+
+# Use manylinux version 2.28 for manylinux instances (except i686 which doesn't have a 2.28 image)
+# This effectively sets the version of gfortran that is used (GCC 12)
+# ALT Linux 10+, RHEL 9+, Debian 11+, Fedora 34+, Mageia 8+, Photon OS 3.0 with updates, Ubuntu 21.04+
+manylinux-aarch64-image = "manylinux_2_28"
+manylinux-x86_64-image = "manylinux_2_28"
+
+# Testing
+test-command = "python -c 'from fgen_example.derived_type import DerivedType; print(DerivedType.from_new_connection())'"
+
+[tool.cibuildwheel.windows]
+before-all = ""
+before-build = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,5 +277,7 @@ manylinux-x86_64-image = "manylinux_2_28"
 test-command = "python -c 'from fgen_example.derived_type import DerivedType; print(DerivedType.from_new_connection())'"
 
 [tool.cibuildwheel.windows]
-before-all = ""
+# Use Ninja for generating the Windows project
+# This is needed because we are using gfortran
+before-all = "set CMAKE_GENERATOR=Ninja"
 before-build = ""


### PR DESCRIPTION
## Description

Adds a step to the CI which builds wheels for a number of different OS/Arch combitions.

These wheels are ready to be published to pypi.

### Supported wheels
Python versions:
~* [ ] cp3.9~ Dropped support following SPEC-0000
* [x] cp3.10
* [x] cp3.11
* [x] cp3.12

OS/Arch:
* [x] manylinux wheels
  * [x] aarch64
  ~* [ ] ppc64le~ Uncommon
  ~* [ ] s390x~ Uncommon
  * [x] x86_64  
* ~[ ] musllinux~ Don't need to support Alpine linux yet (Might be handy for docker containers in future)
* [x] MacOS wheels
  * [x] arm64
  * [x] x86_64
 
* [ ] Windows wheels - Windows wheels are currently blocked by https://gitlab.com/magicc/fgen/-/issues/79
  * [ ] arm64
  * [ ] win32

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
